### PR TITLE
refactor monoid: use mempty

### DIFF
--- a/lib/hallux/internal/finger_tree.ex
+++ b/lib/hallux/internal/finger_tree.ex
@@ -15,9 +15,9 @@ defmodule Hallux.Internal.FingerTree do
 
   @type value :: term
   @type t(value) ::
-          %Empty{monoid: module()}
-          | %Single{monoid: module(), x: value}
-          | %Deep{monoid: module(), l: Digit.t(value), m: t(Node.t(value)), r: Digit.t(value)}
+          %Empty{monoid: Monoid.t()}
+          | %Single{monoid: Monoid.t(), x: value}
+          | %Deep{monoid: Monoid.t(), l: Digit.t(value), m: t(Node.t(value)), r: Digit.t(value)}
   @type t :: t(term)
 
   def cons(%Empty{monoid: m}, x),

--- a/lib/hallux/internal/finger_tree/deep.ex
+++ b/lib/hallux/internal/finger_tree/deep.ex
@@ -43,6 +43,6 @@ defmodule Hallux.Internal.FingerTree.Deep do
 
     def size(%Deep{size: size}), do: size
 
-    def monoid_type(%Deep{monoid: m}), do: struct(m)
+    def monoid_type(%Deep{monoid: m}), do: m
   end
 end

--- a/lib/hallux/internal/finger_tree/empty.ex
+++ b/lib/hallux/internal/finger_tree/empty.ex
@@ -12,8 +12,8 @@ defmodule Hallux.Internal.FingerTree.Empty do
     alias Hallux.Internal.FingerTree.Empty
     alias Hallux.Protocol.Monoid
 
-    def size(%Empty{monoid: m}), do: Monoid.mempty(struct(m))
+    def size(%Empty{monoid: m}), do: Monoid.mempty(m)
 
-    def monoid_type(%Empty{monoid: m}), do: struct(m)
+    def monoid_type(%Empty{monoid: m}), do: m
   end
 end

--- a/lib/hallux/internal/finger_tree/single.ex
+++ b/lib/hallux/internal/finger_tree/single.ex
@@ -14,6 +14,6 @@ defmodule Hallux.Internal.FingerTree.Single do
 
     def size(%Single{x: x}), do: Measured.size(x)
 
-    def monoid_type(%Single{monoid: m}), do: struct(m)
+    def monoid_type(%Single{monoid: m}), do: m
   end
 end

--- a/lib/hallux/seq.ex
+++ b/lib/hallux/seq.ex
@@ -34,6 +34,7 @@ defmodule Hallux.Seq do
   alias Hallux.Internal.FingerTree
   alias Hallux.Internal.FingerTree.Empty
   alias Hallux.Protocol.Measured
+  alias Hallux.Protocol.Monoid
   alias Hallux.Protocol.Reduce
   alias Hallux.Internal.Size
 
@@ -50,7 +51,7 @@ defmodule Hallux.Seq do
       #HalluxSeq<[]>
   """
   @spec new() :: t
-  def new(), do: %__MODULE__{t: %Empty{monoid: Size}}
+  def new(), do: %__MODULE__{t: %Empty{monoid: Monoid.mempty(%Size{})}}
 
   @doc """
   `(O(n))`. Creates a Seq from an enumerable.

--- a/test/hallux/seq_test.exs
+++ b/test/hallux/seq_test.exs
@@ -7,9 +7,11 @@ defmodule Hallux.SeqTest do
   doctest Seq, import: true
 
   property "concat . splitAt = id" do
-    check all s <- seq(),
-              n = Seq.size(s),
-              i <- member_of(0..n) do
+    check all(
+            s <- seq(),
+            n = Seq.size(s),
+            i <- member_of(0..n)
+          ) do
       {l, r} = Seq.split_at(s, i)
       assert_equal(Seq.concat(l, r), s)
     end
@@ -20,7 +22,7 @@ defmodule Hallux.SeqTest do
   end
 
   defp seq(generator \\ term()) do
-    gen all xs <- list_of(generator) do
+    gen all(xs <- list_of(generator)) do
       Seq.new(xs)
     end
   end


### PR DESCRIPTION
needed for product of monoids, like {m1, m2}