### PR TITLE
Extend Seq benchmark with more realistic data

### DIFF
--- a/benchmarks/seq.exs
+++ b/benchmarks/seq.exs
@@ -10,13 +10,37 @@ make_test_input_cons = fn n ->
   |> Enum.reduce(Seq.new(), &Seq.cons(&2, &1))
 end
 
+cons_or_snoc = fn element, seq ->
+  case :rand.uniform(2) do
+    1 -> Seq.cons(seq, element)
+    2 -> Seq.snoc(seq, element)
+  end
+end
+
+make_test_input = fn n ->
+  1..n
+  |> Enum.reduce(Seq.new(), cons_or_snoc)
+end
+
+make_test_input_concat = fn n ->
+  make_test_input.(n)
+  |> Seq.concat(make_test_input_cons.(n))
+  |> Seq.concat(make_test_input_snoc.(n))
+end
+
 inputs = %{
+  "tiny sequence" => make_test_input.(1),
+  "small sequence" => make_test_input.(100),
+  "medium sequence" => make_test_input.(10_000),
   "tiny sequence cons" => make_test_input_cons.(1),
   "small sequence cons" => make_test_input_cons.(100),
   "medium sequence cons" => make_test_input_cons.(10_000),
   "tiny sequence snoc" => make_test_input_snoc.(1),
   "small sequence snoc" => make_test_input_snoc.(100),
-  "medium sequence snoc" => make_test_input_snoc.(10_000)
+  "medium sequence snoc" => make_test_input_snoc.(10_000),
+  "tiny sequence concat" => make_test_input_concat.(1),
+  "small sequence concat" => make_test_input_concat.(100),
+  "medium sequence concat" => make_test_input_concat.(10_000),
 }
 
 Benchee.run(


### PR DESCRIPTION
```
$ mix run benchmarks/seq.exs 
Operating System: Linux
CPU Information: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
Number of Available Cores: 8
Available memory: 23.26 GB
Elixir 1.11.4
Erlang 23.3.1

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 0 ns
parallel: 1
inputs: medium sequence, medium sequence concat, medium sequence cons, medium sequence snoc, small sequence, small sequence concat, small sequence cons, small sequence snoc, tiny sequence, tiny sequence concat, tiny sequence cons, tiny sequence snoc
Estimated total run time: 7 min

Benchmarking concat with input medium sequence...
Benchmarking concat with input medium sequence concat...
Benchmarking concat with input medium sequence cons...
Benchmarking concat with input medium sequence snoc...
Benchmarking concat with input small sequence...
Benchmarking concat with input small sequence concat...
Benchmarking concat with input small sequence cons...
Benchmarking concat with input small sequence snoc...
Benchmarking concat with input tiny sequence...
Benchmarking concat with input tiny sequence concat...
Benchmarking concat with input tiny sequence cons...
Benchmarking concat with input tiny sequence snoc...
Benchmarking cons with input medium sequence...
Benchmarking cons with input medium sequence concat...
Benchmarking cons with input medium sequence cons...
Benchmarking cons with input medium sequence snoc...
Benchmarking cons with input small sequence...
Benchmarking cons with input small sequence concat...
Benchmarking cons with input small sequence cons...
Benchmarking cons with input small sequence snoc...
Benchmarking cons with input tiny sequence...
Benchmarking cons with input tiny sequence concat...
Benchmarking cons with input tiny sequence cons...
Benchmarking cons with input tiny sequence snoc...
Benchmarking snoc with input medium sequence...
Benchmarking snoc with input medium sequence concat...
Benchmarking snoc with input medium sequence cons...
Benchmarking snoc with input medium sequence snoc...
Benchmarking snoc with input small sequence...
Benchmarking snoc with input small sequence concat...
Benchmarking snoc with input small sequence cons...
Benchmarking snoc with input small sequence snoc...
Benchmarking snoc with input tiny sequence...
Benchmarking snoc with input tiny sequence concat...
Benchmarking snoc with input tiny sequence cons...
Benchmarking snoc with input tiny sequence snoc...
Benchmarking view_l with input medium sequence...
Benchmarking view_l with input medium sequence concat...
Benchmarking view_l with input medium sequence cons...
Benchmarking view_l with input medium sequence snoc...
Benchmarking view_l with input small sequence...
Benchmarking view_l with input small sequence concat...
Benchmarking view_l with input small sequence cons...
Benchmarking view_l with input small sequence snoc...
Benchmarking view_l with input tiny sequence...
Benchmarking view_l with input tiny sequence concat...
Benchmarking view_l with input tiny sequence cons...
Benchmarking view_l with input tiny sequence snoc...
Benchmarking view_r with input medium sequence...
Benchmarking view_r with input medium sequence concat...
Benchmarking view_r with input medium sequence cons...
Benchmarking view_r with input medium sequence snoc...
Benchmarking view_r with input small sequence...
Benchmarking view_r with input small sequence concat...
Benchmarking view_r with input small sequence cons...
Benchmarking view_r with input small sequence snoc...
Benchmarking view_r with input tiny sequence...
Benchmarking view_r with input tiny sequence concat...
Benchmarking view_r with input tiny sequence cons...
Benchmarking view_r with input tiny sequence snoc...

##### With input medium sequence #####
Name             ips        average  deviation         median         99th %
cons      2871152.47      348.29 ns  ±2795.52%         282 ns         742 ns
snoc      2641840.18      378.52 ns  ±4202.46%         284 ns         868 ns
view_l     829639.76     1205.34 ns  ±2908.89%         929 ns        3106 ns
view_r     744713.18     1342.80 ns  ±2352.50%         972 ns        3700 ns
concat      51862.41    19281.79 ns    ±97.76%       17188 ns    49703.28 ns

Comparison: 
cons      2871152.47
snoc      2641840.18 - 1.09x slower +30.23 ns
view_l     829639.76 - 3.46x slower +857.05 ns
view_r     744713.18 - 3.86x slower +994.51 ns
concat      51862.41 - 55.36x slower +18933.50 ns

##### With input medium sequence concat #####
Name             ips        average  deviation         median         99th %
cons      2768958.00      361.15 ns ±10138.44%         282 ns         699 ns
snoc      2116272.12      472.53 ns  ±6725.19%         302 ns        1154 ns
view_l     816578.80     1224.62 ns  ±1701.50%        1040 ns        3280 ns
view_r     705750.33     1416.93 ns  ±2436.38%        1110 ns        3964 ns
concat      46074.98    21703.75 ns   ±159.19%       19341 ns    55559.46 ns

Comparison: 
cons      2768958.00
snoc      2116272.12 - 1.31x slower +111.38 ns
view_l     816578.80 - 3.39x slower +863.47 ns
view_r     705750.33 - 3.92x slower +1055.78 ns
concat      46074.98 - 60.10x slower +21342.61 ns

##### With input medium sequence cons #####
Name             ips        average  deviation         median         99th %
snoc      2348753.64      425.76 ns  ±6381.48%         279 ns        1027 ns
cons      2307056.78      433.45 ns  ±7614.75%         309 ns         900 ns
view_l     839760.11     1190.82 ns  ±2809.05%         942 ns        3047 ns
view_r     130033.57     7690.32 ns   ±162.44%        6591 ns       20893 ns
concat      59535.41    16796.73 ns    ±59.81%       14217 ns    45404.75 ns

Comparison: 
snoc      2348753.64
cons      2307056.78 - 1.02x slower +7.69 ns
view_l     839760.11 - 2.80x slower +765.06 ns
view_r     130033.57 - 18.06x slower +7264.56 ns
concat      59535.41 - 39.45x slower +16370.97 ns

##### With input medium sequence snoc #####
Name             ips        average  deviation         median         99th %
snoc      2338228.00      427.67 ns  ±7171.09%         295 ns        1074 ns
cons      2103408.01      475.42 ns  ±6777.74%         301 ns        1211 ns
view_r     809229.19     1235.74 ns  ±1290.67%         925 ns        3512 ns
view_l     144780.42     6907.01 ns   ±191.39%        6128 ns    18511.37 ns
concat      59729.86    16742.05 ns   ±118.91%       14231 ns    46403.96 ns

Comparison: 
snoc      2338228.00
cons      2103408.01 - 1.11x slower +47.74 ns
view_r     809229.19 - 2.89x slower +808.07 ns
view_l     144780.42 - 16.15x slower +6479.34 ns
concat      59729.86 - 39.15x slower +16314.37 ns

##### With input small sequence #####
Name             ips        average  deviation         median         99th %
snoc      2067289.90      483.73 ns  ±7811.75%         310 ns        1238 ns
cons       899740.20     1111.43 ns  ±3077.19%         891 ns        2563 ns
view_r     590915.48     1692.29 ns  ±1749.12%        1359 ns        4959 ns
view_l     585616.10     1707.60 ns  ±1790.37%        1395 ns        4443 ns
concat     123910.57     8070.34 ns   ±159.40%        6693 ns    25869.90 ns

Comparison: 
snoc      2067289.90
cons       899740.20 - 2.30x slower +627.71 ns
view_r     590915.48 - 3.50x slower +1208.56 ns
view_l     585616.10 - 3.53x slower +1223.88 ns
concat     123910.57 - 16.68x slower +7586.61 ns

##### With input small sequence concat #####
Name             ips        average  deviation         median         99th %
snoc      2200596.90      454.42 ns  ±8832.91%         292 ns        1037 ns
cons      1768281.89      565.52 ns  ±6275.70%         378 ns        1419 ns
view_l     687852.08     1453.80 ns  ±1338.34%        1242 ns        3994 ns
view_r     634954.74     1574.92 ns  ±1368.69%        1244 ns        4407 ns
concat      90325.82    11071.03 ns   ±167.28%        9678 ns    31813.68 ns

Comparison: 
snoc      2200596.90
cons      1768281.89 - 1.24x slower +111.10 ns
view_l     687852.08 - 3.20x slower +999.38 ns
view_r     634954.74 - 3.47x slower +1120.49 ns
concat      90325.82 - 24.36x slower +10616.61 ns

##### With input small sequence cons #####
Name             ips        average  deviation         median         99th %
snoc      2227573.75      448.92 ns  ±8278.56%         280 ns        1043 ns
cons      1905901.02      524.69 ns  ±8015.01%         319 ns        1302 ns
view_l     842773.75     1186.56 ns  ±2236.53%         965 ns        3145 ns
view_r     303172.29     3298.45 ns   ±778.18%        2558 ns        9276 ns
concat     165881.83     6028.39 ns   ±336.83%        5379 ns       23502 ns

Comparison: 
snoc      2227573.75
cons      1905901.02 - 1.17x slower +75.77 ns
view_l     842773.75 - 2.64x slower +737.64 ns
view_r     303172.29 - 7.35x slower +2849.54 ns
concat     165881.83 - 13.43x slower +5579.47 ns

##### With input small sequence snoc #####
Name             ips        average  deviation         median         99th %
snoc      2137336.40      467.87 ns  ±8173.69%         299 ns        1079 ns
cons      1869768.49      534.83 ns  ±5544.19%         364 ns        1333 ns
view_r     767207.35     1303.43 ns  ±2200.37%         959 ns        3619 ns
view_l     347038.37     2881.53 ns   ±293.42%        2596 ns        7993 ns
concat     166294.70     6013.42 ns   ±154.63%        5361 ns    24121.09 ns

Comparison: 
snoc      2137336.40
cons      1869768.49 - 1.14x slower +66.95 ns
view_r     767207.35 - 2.79x slower +835.56 ns
view_l     347038.37 - 6.16x slower +2413.65 ns
concat     166294.70 - 12.85x slower +5545.55 ns

##### With input tiny sequence #####
Name             ips        average  deviation         median         99th %
view_l    3979540.22      251.29 ns ±13046.13%         132 ns         595 ns
view_r    3673188.87      272.24 ns ±12884.65%         134 ns         666 ns
cons      1240844.99      805.90 ns  ±3309.01%         640 ns        1836 ns
concat    1228710.63      813.86 ns  ±3054.17%         656 ns        1273 ns
snoc      1145345.69      873.10 ns   ±993.45%         741 ns        2379 ns

Comparison: 
view_l    3979540.22
view_r    3673188.87 - 1.08x slower +20.96 ns
cons      1240844.99 - 3.21x slower +554.62 ns
concat    1228710.63 - 3.24x slower +562.58 ns
snoc      1145345.69 - 3.47x slower +621.81 ns

##### With input tiny sequence concat #####
Name             ips        average  deviation         median         99th %
snoc      2060036.34      485.43 ns  ±4978.53%         368 ns        1341 ns
cons      2039384.63      490.34 ns  ±6862.51%         306 ns        1221 ns
concat    1299293.90      769.65 ns  ±1827.31%         669 ns        1437 ns
view_l     931803.65     1073.19 ns  ±3652.66%         872 ns        2941 ns
view_r     907069.13     1102.45 ns  ±2719.66%         803 ns        3253 ns

Comparison: 
snoc      2060036.34
cons      2039384.63 - 1.01x slower +4.92 ns
concat    1299293.90 - 1.59x slower +284.22 ns
view_l     931803.65 - 2.21x slower +587.76 ns
view_r     907069.13 - 2.27x slower +617.02 ns

##### With input tiny sequence cons #####
Name             ips        average  deviation         median         99th %
view_l    4132627.68      241.98 ns ±13567.42%         126 ns         576 ns
view_r    3723995.75      268.53 ns ±13307.16%         132 ns         665 ns
concat    1304228.00      766.74 ns  ±2978.26%         630 ns        1137 ns
cons      1294429.06      772.54 ns  ±2644.20%         641 ns        1925 ns
snoc       975121.82     1025.51 ns  ±2993.72%         834 ns        2627 ns

Comparison: 
view_l    4132627.68
view_r    3723995.75 - 1.11x slower +26.55 ns
concat    1304228.00 - 3.17x slower +524.76 ns
cons      1294429.06 - 3.19x slower +530.56 ns
snoc       975121.82 - 4.24x slower +783.54 ns

##### With input tiny sequence snoc #####
Name             ips        average  deviation         median         99th %
view_r    3690007.32      271.00 ns ±13683.56%         129 ns         684 ns
view_l    3649359.60      274.02 ns ±14145.97%         134 ns         656 ns
cons      1290328.99      775.00 ns  ±2706.66%         643 ns        2018 ns
concat    1252106.11      798.65 ns  ±3054.23%         651 ns        1294 ns
snoc       970217.19     1030.70 ns  ±3139.01%         840 ns        2647 ns

Comparison: 
view_r    3690007.32
view_l    3649359.60 - 1.01x slower +3.02 ns
cons      1290328.99 - 2.86x slower +503.99 ns
concat    1252106.11 - 2.95x slower +527.65 ns
snoc       970217.19 - 3.80x slower +759.69 ns
```

# Observations

It seems that `view_r` and `view_l` are only logarithmic in certain worst cases, namely only `cons` or only `snoc`. But a typical use case is of course `Seq.new`, which only does `snoc`s, and the `Enumerable` impl only does `view_l`s. So I think it's a good idea to have several benchmarks.